### PR TITLE
def_action support

### DIFF
--- a/lib/quick_script/elastic_search_query.rb
+++ b/lib/quick_script/elastic_search_query.rb
@@ -3,10 +3,11 @@ module QuickScript
   class ElasticSearchQuery
 
     def initialize(opts={})
-      @q = {query:{bool: {must: [], filter: {}}}, size: 50}
+      @q = {sort: [], query:{bool: {must: [], filter: {}}}, size: 50}
       @qb = @q[:query][:bool]
       @qbm = @qb[:must]
       @qbf = @qb[:filter]
+      @qs = @q[:sort]
       @page = 1
     end
 
@@ -66,7 +67,7 @@ module QuickScript
     end
 
     def add_term_filter(field, val)
-      @qbf[:and] = [] if !@qbf[:and].present?
+      @qbf[:and] = [] unless @qbf[:and].present?
       if val.is_a?(Array)
         @qbf[:and] << {:terms => {field => val}}
       else
@@ -75,13 +76,21 @@ module QuickScript
     end
 
     def add_match_filter(field, val)
-      @qbf[:and] = [] if !@qbf[:and].present?
+      @qbf[:and] = [] unless @qbf[:and].present?
       @qbf[:and] << {:match => {field => val}}
-    end 
+    end
 
     def aggs
       @q[:aggregations] ||= {}
       return @q[:aggregations]
+    end
+
+    def add_sort(field, order=nil)
+      if order
+        @qs << {field => order}
+      else
+        @qs << field
+      end
     end
 
   end

--- a/lib/quick_script/model.rb
+++ b/lib/quick_script/model.rb
@@ -6,6 +6,12 @@ module QuickScript
       base.send :extend, ClassMethods
     end
 
+    # creates the instance bound to self of the anonymous "actions"
+    # class that resulted from the calls to def_action
+    def actions
+      @actions ||= self.class.actions_class.new(self)
+    end
+
     module ClassMethods
       def attr_alias(new_attr, old_attr)
         alias_method(new_attr, old_attr)
@@ -29,6 +35,35 @@ module QuickScript
           end
         end
       end
+
+      # class created once per mixin to contain all of the methods
+      # created using def_action
+      def actions_class
+        @actions_class ||= Class.new do
+          attr_reader :target
+
+          define_method(:initialize) do |target|
+            @target = target
+          end
+        end
+      end
+
+      # create an action inside the actions_class that wraps the body
+      # and returns the standard dictionary reply required for an
+      # action
+      def def_action(method_name, &block)
+        actions_class.class_eval do
+          define_method(method_name) do |*args|
+            begin
+              result = self.target.instance_exec(*args, &block)
+              {success: true, data: result}
+            rescue => ex
+              {success: false, reason: ex}
+            end
+          end
+        end
+      end
+
 
     end
 


### PR DESCRIPTION
Example usage:

```
class Model
  include Action

  attr_reader :name

  def initialize(name)
    @name = name
  end

  def_action(:say_hi) do
    "I'm #{@name}"
  end

  def_action(:greet) do |other|
    "Greetings #{other}"
  end

  def_action(:buggy) do
    1 / 0
  end
end

p1 = Model.new "Dog"
p2 = Model.new "Cat"

puts p1.actions.say_hi  # {success: true, data: "I'm Dog"}
puts p2.actions.say_hi  # {success: true, data: "I'm Cat"}
puts p1.actions.buggy   # {success: false}
```
